### PR TITLE
Removed Mods access to other members locks.

### DIFF
--- a/src/com/sbezboro/standardgroups/model/Lock.java
+++ b/src/com/sbezboro/standardgroups/model/Lock.java
@@ -117,7 +117,7 @@ public class Lock extends PersistableImpl implements Persistable {
 
 	// Groups moderators always have access
 	public boolean hasAccess(StandardPlayer player) {
-		return memberUuids.contains(player.getUuidString()) || group.isModerator(player) || group.isLeader(player);
+		return memberUuids.contains(player.getUuidString()) || group.isLeader(player);
 	}
 
 	public void addMember(StandardPlayer player) {


### PR DESCRIPTION
Saw some complaints that mods can get into leaders chests, it should be fine with leaders opening mods / normal group members locks
