### PR TITLE
Prevent lava/water griefing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,5 +11,7 @@ group-power-min-value: -15.0
 group-power-max-value: 20.0
 power-damage-modifier: 1.0
 spawn-claim-cost: 5
+prevent-lava-griefing: false
+prevent-water-griefing: false
 
 

--- a/src/com/sbezboro/standardgroups/StandardConfig.java
+++ b/src/com/sbezboro/standardgroups/StandardConfig.java
@@ -22,7 +22,9 @@ public class StandardConfig {
 	private double groupPowerMaxValue;
 	private double powerDamageModifier;
 	private int spawnClaimCost;
-  
+	private boolean preventLavaGriefing;
+	private boolean preventWaterGriefing;
+
 	public StandardConfig(StandardPlugin plugin) {
 		this.plugin = plugin;
 	}
@@ -43,6 +45,8 @@ public class StandardConfig {
 		groupPowerMaxValue = config.getDouble("group-power-max-value");
 		powerDamageModifier = config.getDouble("power-damage-modifier");
 		spawnClaimCost = config.getInt("spawn-claim-cost");
+		preventLavaGriefing = config.getBoolean("prevent-lava-griefing");
+		preventWaterGriefing = config.getBoolean("prevent-water-griefing");
 	}
 
 	public boolean isDebug() {
@@ -99,6 +103,14 @@ public class StandardConfig {
 
 	public int getSpawnClaimCost() {
 		return spawnClaimCost;
+	}
+
+	public boolean getPreventLavaGriefing() {
+		return preventLavaGriefing;
+	}
+
+	public boolean getPreventWaterGriefing() {
+		return preventWaterGriefing;
 	}
 
 }

--- a/src/com/sbezboro/standardgroups/StandardGroups.java
+++ b/src/com/sbezboro/standardgroups/StandardGroups.java
@@ -168,6 +168,7 @@ public class StandardGroups extends JavaPlugin implements SubPlugin {
 		pluginManager.registerEvents(new HangingBreakListener(basePlugin, this), this);
 		pluginManager.registerEvents(new HangingPlaceListener(basePlugin, this), this);
 		pluginManager.registerEvents(new InventoryMoveListener(basePlugin, this), this);
+		pluginManager.registerEvents(new LiquidFlowListener(basePlugin, this), this);
 		pluginManager.registerEvents(new PlayerChatListener(basePlugin, this), this);
 		pluginManager.registerEvents(new PlayerBucketEmptyListener(basePlugin, this), this);
 		pluginManager.registerEvents(new PlayerBucketFillListener(basePlugin, this), this);
@@ -229,6 +230,14 @@ public class StandardGroups extends JavaPlugin implements SubPlugin {
 
 	public int getSpawnClaimCost() {
 		return config.getSpawnClaimCost();
+	}
+
+	public boolean getPreventLavaGriefing() {
+		return config.getPreventLavaGriefing();
+	}
+
+	public boolean getPreventWaterGriefing() {
+		return config.getPreventWaterGriefing();
 	}
 
 	public GroupManager getGroupManager() {

--- a/src/com/sbezboro/standardgroups/listeners/LiquidFlowListener.java
+++ b/src/com/sbezboro/standardgroups/listeners/LiquidFlowListener.java
@@ -1,0 +1,43 @@
+package com.sbezboro.standardgroups.listeners;
+
+import com.sbezboro.standardgroups.StandardGroups;
+import com.sbezboro.standardgroups.managers.GroupManager;
+import com.sbezboro.standardgroups.model.Group;
+import com.sbezboro.standardplugin.StandardPlugin;
+import com.sbezboro.standardplugin.SubPluginEventListener;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockFromToEvent;
+
+public class LiquidFlowListener extends SubPluginEventListener<StandardGroups> implements Listener {
+    public LiquidFlowListener(StandardPlugin plugin, StandardGroups subPlugin) {
+        super(plugin, subPlugin);
+    }
+
+    // Prevent liquids flowing across group boundaries because this can lead
+    // to various kinds of griefing. In the worst case, if both lava and water
+    // can flow across group boundaries, cobble monsters can form in the spawn
+    // area.
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockFromTo(BlockFromToEvent event) {
+        Location fromLocation = event.getBlock().getLocation();
+        Location toLocation = event.getToBlock().getLocation();
+
+        GroupManager groupManager = subPlugin.getGroupManager();
+
+        Group fromGroup = groupManager.getGroupByLocation(fromLocation);
+        Group toGroup = groupManager.getGroupByLocation(toLocation);
+
+        if (fromGroup != toGroup) {
+            if (subPlugin.getPreventLavaGriefing() && event.getBlock().getType() == Material.LAVA) {
+                event.setCancelled(true);
+            } else if (subPlugin.getPreventWaterGriefing() && event.getBlock().getType() == Material.WATER) {
+                event.setCancelled(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change prevents creation of cobble monsters in the spawn area.

It also prevents cobble monsters on enemy claims and all other kinds
of lava/water griefing of enemy claims. Lava and water can still
flow as normal on unclaimed land, and also within claims.

Specifically two new options are added:

prevent-lava-griefing: prevents lava flowing across group boundaries
prevent-water-griefing: prevents water flowing across group boundaries

These options default to false (the existing behavior) and can
be switched on independently. Only enabling the lava grief prevention
option should be sufficient to address cobble monsters.